### PR TITLE
fix connection with peer over ipv6

### DIFF
--- a/src/sstp-client.c
+++ b/src/sstp-client.c
@@ -635,7 +635,7 @@ static status_t sstp_client_lookup(sstp_url_st *uri, sstp_peer_st *peer)
 
     /* Save the results for later */
     strncpy(peer->name, (list->ai_canonname) ? : uri->host, sizeof(peer->name));
-    memcpy(&peer->addr, list->ai_addr, sizeof(peer->addr));
+    memcpy(&peer->addr, list->ai_addr, list->ai_addrlen);
     peer->alen = list->ai_addrlen;
 
     log_info("Resolved %s to %s", peer->name, 

--- a/src/sstp-client.h
+++ b/src/sstp-client.h
@@ -36,7 +36,11 @@ typedef struct sstp_peer
     char name[255];
 
     /*! The address information of our peer */
-    struct sockaddr addr;
+    union {
+        struct sockaddr addr;
+        struct sockaddr_in addr4;
+        struct sockaddr_in6 addr6;
+    };
 
     /*! The address length */
     int alen;

--- a/src/sstp-stream.c
+++ b/src/sstp-stream.c
@@ -939,7 +939,7 @@ status_t sstp_stream_connect(sstp_stream_st *stream, struct sockaddr *addr,
     int ret = (-1);
 
     /* Create the socket */
-    stream->ssock = socket(PF_INET, SOCK_STREAM, 0);
+    stream->ssock = socket(addr->sa_family, SOCK_STREAM, 0);
     if (0 > stream->ssock)
     {          
         log_err("Could not create socket");


### PR DESCRIPTION
struct sockaddr size is not enough for storing ipv6
socket address, therefore it gets corrupted and no
connection can be established due wrong address.